### PR TITLE
ci(fix): Override PAX URL maven repositories to use https

### DIFF
--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -49,8 +49,8 @@ jobs:
           REVISION=$(echo $FINAL_RELEASE_VERSION | tr -d 'jahia' | cut -d'-' -f2)
           NEXT_REVISION=$(expr $REVISION + 1)
           NEXT_DEVELOPMENT_VERSION="$(echo $FINAL_RELEASE_VERSION | cut -d'-' -f1)-jahia${NEXT_REVISION}"-SNAPSHOT # e.g. 2.20.12-jahia2-SNAPSHOT
-          mvn -ntp -B -s .github/maven.settings.xml -DdryRun=false -Dmaven.test.skip=false -Dmaven.javadoc.skip=true -Dgpg.skip=true -Drat.skip=true -DskipLocalStaging=true \
+          mvn -Dorg.ops4j.pax.url.mvn.repositories=https://devtools.jahia.com/nexus/content/groups/public@id=central -ntp -B -s .github/maven.settings.xml -DdryRun=false -Dmaven.test.skip=false -Dmaven.javadoc.skip=true -Dgpg.skip=true -Drat.skip=true -DskipLocalStaging=true \
           -Dtag=$TAG_VERSION -DreleaseVersion=$FINAL_RELEASE_VERSION -DdevelopmentVersion="$NEXT_DEVELOPMENT_VERSION" -DscmCommentPrefix="[skip ci] [maven-release-plugin] " \
           -Darguments="-s .github/maven.settings.xml -Dmaven.test.skip=false -Dmaven.javadoc.skip=true -Dgpg.skip=true -Drat.skip=true -DskipLocalStaging=true -Papache-release" -Papache-release -Dusername=git release:prepare 
-          mvn -ntp -B -s .github/maven.settings.xml -DdryRun=false -Dmaven.test.skip=false -Dmaven.javadoc.skip=true -Dgpg.skip=true -Drat.skip=true -DskipLocalStaging=true \
+          mvn -Dorg.ops4j.pax.url.mvn.repositories=https://devtools.jahia.com/nexus/content/groups/public@id=central -ntp -B -s .github/maven.settings.xml -DdryRun=false -Dmaven.test.skip=false -Dmaven.javadoc.skip=true -Dgpg.skip=true -Drat.skip=true -DskipLocalStaging=true \
           -Darguments="-s .github/maven.settings.xml -Dmaven.test.skip=false -Dmaven.javadoc.skip=true -Dgpg.skip=true -Drat.skip=true -DskipLocalStaging=true -Papache-release" -Papache-release  -Dusername=git release:perform


### PR DESCRIPTION
### Description
Force the use of an https URL for PAX by specifying the `org.ops4j.pax.url.mvn.repositories` property.
Otherwise, the release fails with:
```
[INFO] --- failsafe:3.3.0:integration-test (default) @ jackrabbit-it-osgi ---
[INFO] Using auto detected provider org.apache.maven.surefire.junit4.JUnit4Provider
[INFO] 
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running org.apache.jackrabbit.osgi.OSGiIT


[ERROR] Tests run: 1, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 1.394 s <<< FAILURE! -- in org.apache.jackrabbit.osgi.OSGiIT
[ERROR] org.apache.jackrabbit.osgi.OSGiIT -- Time elapsed: 1.378 s <<< ERROR!
org.ops4j.pax.exam.TestContainerException: [link:classpath:META-INF/links/org.ops4j.pax.exam.inject.link] could not be downloaded
        at org.ops4j.pax.exam.forked.provision.PlatformImpl.download(PlatformImpl.java:146)
        at org.ops4j.pax.exam.forked.ForkedTestContainer.downloadBundle(ForkedTestContainer.java:356)
        at org.ops4j.pax.exam.forked.ForkedTestContainer.installAndStartBundles(ForkedTestContainer.java:284)
        at org.ops4j.pax.exam.forked.ForkedTestContainer.start(ForkedTestContainer.java:165)
        at org.ops4j.pax.exam.spi.reactors.EagerSingleStagedReactor.setUp(EagerSingleStagedReactor.java:86)
        at org.ops4j.pax.exam.spi.reactors.EagerSingleStagedReactor.beforeClass(EagerSingleStagedReactor.java:136)
        at org.ops4j.pax.exam.spi.reactors.ReactorManager.beforeClass(ReactorManager.java:457)
        at org.ops4j.pax.exam.junit.impl.ProbeRunner.run(ProbeRunner.java:97)
        at org.ops4j.pax.exam.junit.PaxExam.run(PaxExam.java:93)
        at org.apache.maven.surefire.junit4.JUnit4Provider.execute(JUnit4Provider.java:316)
        at org.apache.maven.surefire.junit4.JUnit4Provider.executeWithRerun(JUnit4Provider.java:240)
        at org.apache.maven.surefire.junit4.JUnit4Provider.executeTestSet(JUnit4Provider.java:214)
        at org.apache.maven.surefire.junit4.JUnit4Provider.invoke(JUnit4Provider.java:155)
        at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:385)
        at org.apache.maven.surefire.booter.ForkedBooter.execute(ForkedBooter.java:162)
        at org.apache.maven.surefire.booter.ForkedBooter.run(ForkedBooter.java:507)
        at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:495)
Caused by: java.io.IOException: Error resolving artifact org.ops4j.pax.exam:pax-exam-inject:jar:4.13.1: Could not transfer artifact org.ops4j.pax.exam:pax-exam-inject:jar:4.13.1 from/to central (http://repo1.maven.org/maven2/): Failed to transfer file: http://repo1.maven.org/maven2/org/ops4j/pax/exam/pax-exam-inject/4.13.1/pax-exam-inject-4.13.1.jar. Return code is: 501 , ReasonPhrase:Not Implemented.
        at org.ops4j.pax.url.mvn.internal.AetherBasedResolver.resolve(AetherBasedResolver.java:626)
        at org.ops4j.pax.url.mvn.internal.AetherBasedResolver.resolve(AetherBasedResolver.java:570)
        at org.ops4j.pax.url.mvn.internal.AetherBasedResolver.resolve(AetherBasedResolver.java:548)
        at org.ops4j.pax.url.mvn.internal.AetherBasedResolver.resolve(AetherBasedResolver.java:523)
        at org.ops4j.pax.url.mvn.internal.Connection.getInputStream(Connection.java:123)
        at java.base/java.net.URL.openStream(URL.java:1165)
        at org.ops4j.pax.exam.forked.provision.StreamUtils.streamCopy(StreamUtils.java:103)
        at org.ops4j.pax.exam.forked.provision.PlatformImpl.download(PlatformImpl.java:133)
        ... 16 more

[INFO] 
[INFO] Results:
[INFO] 
[ERROR] Errors: 
[ERROR]   OSGiIT » TestContainer [link:classpath:META-INF/links/org.ops4j.pax.exam.inject.link] could not be downloaded
[INFO] 
[ERROR] Tests run: 1, Failures: 0, Errors: 1, Skipped: 0
[INFO] 
[INFO] 
```


> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
