### PR TITLE
ci(release): Use local branch instead of a detached HEAD

### DIFF
--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -28,6 +28,7 @@ jobs:
           git config user.email 'jahia-ci@jahia.com'
           git config user.name 'Jahia CI'
           git fetch --all
+          git checkout -B ${{ github.event.release.target_commitish }}
           git tag --delete ${{ github.event.release.tag_name }}
           git push origin :refs/tags/${{ github.event.release.tag_name }}
       - uses: actions/cache@v4


### PR DESCRIPTION
### Description

Use a local branch when doing the checkout from the tag instead of using a detached HEAD.
Fixes the error that happens during the release (see [this run](https://github.com/Jahia/jackrabbit/actions/runs/20366707235/job/58523406294)):
```
[INFO] 11/17 prepare:scm-commit-release
[INFO] Checking in modified POMs...
[INFO] Executing: /bin/sh -c cd '/home/runner/work/jackrabbit/jackrabbit' && 'git' 'add' '--' 'jackrabbit-parent/pom.xml' 'jackrabbit-jcr-commons/pom.xml' 'jackrabbit-jcr-tests/pom.xml' 'jackrabbit-data/pom.xml' 'jackrabbit-aws-ext/pom.xml' 'jackrabbit-spi/pom.xml' 'jackrabbit-spi-commons/pom.xml' 'jackrabbit-core/pom.xml' 'jackrabbit-vfs-ext/pom.xml' 'jackrabbit-webdav/pom.xml' 'jackrabbit-jcr-server/pom.xml' 'jackrabbit-jcr-servlet/pom.xml' 'jackrabbit-webapp/pom.xml' 'jackrabbit-jca/pom.xml' 'jackrabbit-jcr2spi/pom.xml' 'jackrabbit-spi2jcr/pom.xml' 'jackrabbit-spi2dav/pom.xml' 'jackrabbit-jcr2dav/pom.xml' 'jackrabbit-jcr-client/pom.xml' 'jackrabbit-standalone-components/pom.xml' 'jackrabbit-standalone/pom.xml' 'jackrabbit-it-osgi/pom.xml' 'pom.xml'
[INFO] Working directory: /home/runner/work/jackrabbit/jackrabbit
[INFO] Executing: /bin/sh -c cd '/home/runner/work/jackrabbit/jackrabbit' && 'git' 'rev-parse' '--show-prefix'
[INFO] Working directory: /home/runner/work/jackrabbit/jackrabbit
[INFO] Executing: /bin/sh -c cd '/home/runner/work/jackrabbit/jackrabbit' && 'git' 'status' '--porcelain' '.'
[INFO] Working directory: /home/runner/work/jackrabbit/jackrabbit
Warning:  Ignoring unrecognized line: ?? jackrabbit-aws-ext/pom.xml.releaseBackup
Warning:  Ignoring unrecognized line: ?? jackrabbit-core/pom.xml.releaseBackup
Warning:  Ignoring unrecognized line: ?? jackrabbit-data/pom.xml.releaseBackup
Warning:  Ignoring unrecognized line: ?? jackrabbit-it-osgi/pom.xml.releaseBackup
Warning:  Ignoring unrecognized line: ?? jackrabbit-jca/pom.xml.releaseBackup
Warning:  Ignoring unrecognized line: ?? jackrabbit-jcr-client/pom.xml.releaseBackup
Warning:  Ignoring unrecognized line: ?? jackrabbit-jcr-commons/pom.xml.releaseBackup
Warning:  Ignoring unrecognized line: ?? jackrabbit-jcr-server/pom.xml.releaseBackup
Warning:  Ignoring unrecognized line: ?? jackrabbit-jcr-servlet/pom.xml.releaseBackup
Warning:  Ignoring unrecognized line: ?? jackrabbit-jcr-tests/pom.xml.releaseBackup
Warning:  Ignoring unrecognized line: ?? jackrabbit-jcr2dav/pom.xml.releaseBackup
Warning:  Ignoring unrecognized line: ?? jackrabbit-jcr2spi/pom.xml.releaseBackup
Warning:  Ignoring unrecognized line: ?? jackrabbit-parent/pom.xml.releaseBackup
Warning:  Ignoring unrecognized line: ?? jackrabbit-spi-commons/pom.xml.releaseBackup
Warning:  Ignoring unrecognized line: ?? jackrabbit-spi/pom.xml.releaseBackup
Warning:  Ignoring unrecognized line: ?? jackrabbit-spi2dav/pom.xml.releaseBackup
Warning:  Ignoring unrecognized line: ?? jackrabbit-spi2jcr/pom.xml.releaseBackup
Warning:  Ignoring unrecognized line: ?? jackrabbit-standalone-components/pom.xml.releaseBackup
Warning:  Ignoring unrecognized line: ?? jackrabbit-standalone/pom.xml.releaseBackup
Warning:  Ignoring unrecognized line: ?? jackrabbit-vfs-ext/pom.xml.releaseBackup
Warning:  Ignoring unrecognized line: ?? jackrabbit-webapp/pom.xml.releaseBackup
Warning:  Ignoring unrecognized line: ?? jackrabbit-webdav/pom.xml.releaseBackup
Warning:  Ignoring unrecognized line: ?? pom.xml.releaseBackup
Warning:  Ignoring unrecognized line: ?? release.properties
[INFO] Executing: /bin/sh -c cd '/home/runner/work/jackrabbit/jackrabbit' && 'git' 'commit' '--verbose' '-F' '/tmp/maven-scm-292360630.commit'
[INFO] Working directory: /home/runner/work/jackrabbit/jackrabbit
[INFO] Executing: /bin/sh -c cd '/home/runner/work/jackrabbit/jackrabbit' && 'git' 'symbolic-ref' 'HEAD'
[INFO] Working directory: /home/runner/work/jackrabbit/jackrabbit
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for Apache Jackrabbit 2.22.0-jahia1-SNAPSHOT:
[INFO] 
[INFO] Jackrabbit Parent POM .............................. SKIPPED
[INFO] Jackrabbit JCR Commons ............................. SKIPPED
[INFO] Jackrabbit JCR Tests ............................... SKIPPED
[INFO] Jackrabbit Data .................................... SKIPPED
[INFO] Jackrabbit AWS Extension ........................... SKIPPED
[INFO] Jackrabbit SPI ..................................... SKIPPED
[INFO] Jackrabbit SPI Commons ............................. SKIPPED
[INFO] Jackrabbit Core .................................... SKIPPED
[INFO] Jackrabbit VFS Extension ........................... SKIPPED
[INFO] Jackrabbit WebDAV Library .......................... SKIPPED
[INFO] Jackrabbit JCR Server .............................. SKIPPED
[INFO] Jackrabbit JCR Servlets ............................ SKIPPED
[INFO] Jackrabbit Web Application ......................... SKIPPED
[INFO] Jackrabbit JCA Resource Adapter .................... SKIPPED
[INFO] Jackrabbit JCR to SPI .............................. SKIPPED
[INFO] Jackrabbit SPI to JCR .............................. SKIPPED
[INFO] Jackrabbit SPI to WebDAV ........................... SKIPPED
[INFO] Jackrabbit JCR to WebDAV ........................... SKIPPED
[INFO] Jackrabbit JCR Client .............................. SKIPPED
[INFO] Jackrabbit Standalone Components ................... SKIPPED
[INFO] Jackrabbit Standalone .............................. SKIPPED
[INFO] Jackrabbit Integration Tests for OSGi deployments .. SKIPPED
[INFO] Apache Jackrabbit .................................. FAILURE [10:22 min]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  10:32 min
[INFO] Finished at: 2025-12-19T10:17:55Z
[INFO] ------------------------------------------------------------------------
Error:  Failed to execute goal org.apache.maven.plugins:maven-release-plugin:3.0.1:prepare (default-cli) on project jackrabbit: An error is occurred in the checkin process: Exception while executing SCM command. Detecting the current branch failed: fatal: ref HEAD is not a symbolic ref -> [Help 1]
Error:  
Error:  To see the full stack trace of the errors, re-run Maven with the -e switch.
Error:  Re-run Maven using the -X switch to enable full debug logging.
Error:  
Error:  For more information about the errors and possible solutions, please read the following articles:
Error:  [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoExecutionException
Error:  
Error:  After correcting the problems, you can resume the build with the command
Error:    mvn <args> -rf :jackrabbit
Error: Process completed with exit code 1.
```

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
